### PR TITLE
Running last specs more effectively

### DIFF
--- a/plugin/mocha.vim
+++ b/plugin/mocha.vim
@@ -103,7 +103,7 @@ function! RunCurrentSpecFile()
     call SetLastSpecFile(@%)
     call RunSpecs(l:spec)
   else
-    call RunLastSpec()
+    call RunLastSpecFile()
   endif
 endfunction
 
@@ -117,14 +117,7 @@ function! RunNearestSpec()
     call SetLastNearestSpec(l:spec)
     call RunSpecs(l:spec)
   else
-    call RunLastSpec()
-  endif
-endfunction
-
-" Last Spec
-function! RunLastSpec()
-  if exists("s:last_spec_command")
-    call RunSpecs(s:last_spec_command)
+    call RunLastNearestSpec()
   endif
 endfunction
 
@@ -140,17 +133,46 @@ function! InSpecFile()
   return match(l:contents, l:regex) != -1
 endfunction
 
+" Storing last commands
+" =====================
+
 " Store last spec name
 function! SetLastNearestSpec(nearestSpec)
   let s:last_nearest_spec = a:nearestSpec
 endfunction
+
 " Store last spec file
 function! SetLastSpecFile(file)
   let s:last_spec_file = a:file
 endfunction
+
 " Cache Last Spec Command
 function! SetLastSpecCommand(spec)
   let s:last_spec_command = a:spec
+endfunction
+
+" Running last commands
+" =====================
+
+" Run Last Nearest Spec
+function! RunLastNearestSpec()
+  if exists("s:last_nearest_spec")
+    call RunSpecs(s:last_nearest_spec)
+  endif
+endfunction
+
+" Run Last Spec File
+function! RunLastSpecFile()
+  if exists("s:last_spec_file")
+    call RunSpecs(s:last_spec_file)
+  endif
+endfunction
+
+" Run Entire Last Spec
+function! RunLastSpec()
+  if exists("s:last_spec_command")
+    call RunSpecs(s:last_spec_command)
+  endif
 endfunction
 
 " Spec Runner
@@ -162,4 +184,3 @@ function! RunSpecs(spec)
     execute substitute(g:spec_command, "{spec}", a:spec, "g")
   end
 endfunction
-

--- a/plugin/mocha.vim
+++ b/plugin/mocha.vim
@@ -100,6 +100,7 @@ function! RunCurrentSpecFile()
   if InSpecFile()
     let l:spec = @%
     call SetLastSpecCommand(l:spec)
+    call SetLastSpecFile(@%)
     call RunSpecs(l:spec)
   else
     call RunLastSpec()
@@ -112,6 +113,8 @@ function! RunNearestSpec()
     call s:GetNearestTest()
     let l:spec = @% . " -g '" . s:nearestTest . "'"
     call SetLastSpecCommand(l:spec)
+    call SetLastSpecFile(@%)
+    call SetLastNearestSpec(l:spec)
     call RunSpecs(l:spec)
   else
     call RunLastSpec()
@@ -131,13 +134,20 @@ function! InSpecFile()
   if match(expand('%'), '\v(.js|.coffee)$') == -1
     return 0
   endif
-
   " Check for describe block
   let l:contents = join(getline(1,'$'), "\n")
   let l:regex = '\v<describe\s*\(?\s*[''"](.*)[''"]\s*,'
   return match(l:contents, l:regex) != -1
 endfunction
 
+" Store last spec name
+function! SetLastNearestSpec(nearestSpec)
+  let s:last_nearest_spec = a:nearestSpec
+endfunction
+" Store last spec file
+function! SetLastSpecFile(file)
+  let s:last_spec_file = a:file
+endfunction
 " Cache Last Spec Command
 function! SetLastSpecCommand(spec)
   let s:last_spec_command = a:spec


### PR DESCRIPTION
This is another thing I loved about vim-rspec but missed in vim-mocha, what do you think?
If not in spec file, RunNearestSpec will run the last ran "nearest spec", and RunCurrentSpecFile will run the last file that was under test. This improves workflow when trying to make a single test work. Once it's green, you can hit \<leader\>t to run all the specs in the last executed spec file. [Here](https://robots.thoughtbot.com/an-improved-vim-rspec-workflow)'s more info.